### PR TITLE
remove extraneous ``tsx in r3f tutorial

### DIFF
--- a/content/docs/0.5/100-getting-started/100-with-react-three-fiber.mdx
+++ b/content/docs/0.5/100-getting-started/100-with-react-three-fiber.mdx
@@ -265,8 +265,6 @@ Then replace the `<PerspectiveCamera />` element with `<EditableCamera />`.
 </Canvas>
 ```
 
-```tsx
-
 ## Animating objects
 
 So far, we can move around these objects and edit their properties, but we can also animate them.


### PR DESCRIPTION
Caught this while going through the docs.

[Before](https://www.theatrejs.com/docs/latest/getting-started/with-react-three-fiber#animating-objects)
<img width="667" alt="image" src="https://user-images.githubusercontent.com/362590/201342046-2432ed88-799c-45b7-93ae-3666fb2c7b3a.png">

[After](https://deploy-preview-2--theatrejs-dot-com.netlify.app/docs/latest/getting-started/with-react-three-fiber#animating-objects)
<img width="673" alt="image" src="https://user-images.githubusercontent.com/362590/201342095-cbad6b25-f079-4504-a6f3-6dfa5eff5e22.png">

This project is awesome, can't wait to use it!