### PR TITLE
Fix for a minor oversight in the documentation

### DIFF
--- a/content/docs/0.5/100-getting-started/100-with-react-three-fiber.mdx
+++ b/content/docs/0.5/100-getting-started/100-with-react-three-fiber.mdx
@@ -269,7 +269,7 @@ use it for rendering, and it is also editable.
 Let's remove the `camera` prop from the `Canvas` element, and add our `PerspectiveCamera` component from `@theatre/r3f`.
 
 ```tsx
-import {PerspectiveCamera} from '@react-three/r3f'
+import {PerspectiveCamera} from '@theatre/r3f'
 ```
 
 ```tsx


### PR DESCRIPTION
While following "Getting started" I noticed that the documentation suggests (correctly) that `PerspectiveCamera` should be imported from `@theatre/r3f`. However, the example code imports it from `@react-three/r3f`.

This is a minor oversight but might be helpful for less experienced developers.

Cheers, and great work 👏